### PR TITLE
Add feature to stop budification if an element already has dir attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ padding-inline-end: 10px;
 border-inline-start: 1px;
 ```
 
+## Configuration
+
+To use this gem with custom configuration, use the following syntax and pass
+options while creating an instance of bidifier:
+
+```rb
+options = {
+  # ...
+}
+
+bidifier = Bidify::HtmlStringBidifier.new(options)
+
+puts bidifier.apply('<div>input stringified html</div>')
+```
+
+### Options
+
+The following is the list of options with their default values
+- `greedy: false`
+
+    By default, bidification stops when it reaches an element that has `dir`
+    attribute. Use `true` to disregard any existing `dir` attributes.
+- `with_table_support: false`
+
+    Use `true` to add table tags support.
+
 ## License
 
 This project is a Free/Libre and Open Source software released under LGPLv3 license.

--- a/lib/bidify/bidifier.rb
+++ b/lib/bidify/bidifier.rb
@@ -46,6 +46,8 @@ module Bidify
     end
 
     def stop_recursion_at?(node)
+      return false if @options[:greedy] == true
+
       node.has_attribute?('dir')
     end
   end

--- a/lib/bidify/bidifier.rb
+++ b/lib/bidify/bidifier.rb
@@ -29,6 +29,8 @@ module Bidify
       seen_the_first_bidifiable_element = false
 
       html_node.children.each do |child_node|
+        next if stop_recursion_at?(child_node)
+
         bidify_recursively(child_node)
 
         if (options[:root] || seen_the_first_bidifiable_element) && @bidifiable_tags.include?(child_node.name)
@@ -41,6 +43,10 @@ module Bidify
 
     def actual_content?(node)
       node.element? || (node.text? && !node.blank?)
+    end
+
+    def stop_recursion_at?(node)
+      node.has_attribute?('dir')
     end
   end
 end

--- a/spec/html_string_bidifier_spec.rb
+++ b/spec/html_string_bidifier_spec.rb
@@ -231,4 +231,31 @@ describe 'Bidify' do
 
     expect(actual_output).to eq expected_output
   end
+
+  it 'with `greedy: true` option, it disregard any exisitng dir attribute' do
+    input = <<~HTML
+      <div>
+        <p>Item 1</p>
+        <div dir="ltr">
+          <p>Item 2</p>
+          <p>Item 3</p>
+        </div>
+      </div>
+    HTML
+
+    expected_output = <<~HTML
+      <div dir="auto">
+        <p>Item 1</p>
+        <div dir="auto">
+          <p>Item 2</p>
+          <p dir="auto">Item 3</p>
+        </div>
+      </div>
+    HTML
+
+    bidifier = Bidify::HtmlStringBidifier.new(greedy: true)
+    actual_output = bidifier.apply(input)
+
+    expect(actual_output).to eq expected_output
+  end
 end

--- a/spec/html_string_bidifier_spec.rb
+++ b/spec/html_string_bidifier_spec.rb
@@ -179,6 +179,32 @@ describe 'Bidify' do
 
       expect(actual_output).to eq expected_output
     end
+
+    it 'stops recursive bidification on an element with explicit dir attribute' do
+      input = <<~HTML
+        <div>
+          <p>Item 1</p>
+          <div dir="ltr">
+            <p>Item 2</p>
+            <p>Item 3</p>
+          </div>
+        </div>
+      HTML
+
+      expected_output = <<~HTML
+        <div dir="auto">
+          <p>Item 1</p>
+          <div dir="ltr">
+            <p>Item 2</p>
+            <p>Item 3</p>
+          </div>
+        </div>
+      HTML
+
+      actual_output = bidifier.apply(input)
+
+      expect(actual_output).to eq expected_output
+    end
   end
 
   it 'bidifies a table with :with_table_support option' do


### PR DESCRIPTION
By default, bidification stops if we reach an element with `dir` attribution (regardless of its value)

By passing `greedy: true` option, bidification disregards any possible existing `dir` attributes.

closes #3 